### PR TITLE
Minimum pings for SOR

### DIFF
--- a/R/sor_fill_missing.R
+++ b/R/sor_fill_missing.R
@@ -54,11 +54,18 @@ sor_fill_missing <- function(height_paths, spread_paths, rds_dir) {
     est_height <- FALSE
     est_width <- FALSE
     
+    if(is.null(sel_dat[['height']])) { 
+      warning("sor_fill_missing: Skipping ", rds_paths[mm], " because no height data were found.")
+      next 
+      }
+    
     # Estimate height if height is NA or there are less than 150 height measurements
     if(is.na(sel_dat[['height']]$net_height_pings) | sel_dat[['height']]$net_height_pings < 150) {
+      
       est_height <- TRUE
+      
     }
-    
+
     if(est_height) {
       final_height <- data.frame(edit_net_height = sel_dat[['height']]$edit_net_height,
                                  net_height_method = 4,

--- a/R/sor_run.R
+++ b/R/sor_run.R
@@ -6,10 +6,11 @@
 #' @param cruise Cruise number as a numeric vector (e.g. 202202). Must provide rds_dir or all of region, vessel, cruise, survey.
 #' @param vessel vessel ID number as a numeric vector (e.g. 162 for Alaska Knight. Must provide rds_dir or all of region, vessel, cruise, survey.
 #' @param survey Survey name prefix to use in filename (e.g. NBS_2022). Must provide rds_dir or all of region, vessel, cruise, survey.
+#' @param min_pings_for_sor Minimum number of ping required to conduct sequential outlier rejection (default = 50).
 #' @return Reads in measurement data from _ping.rds files from rds_dir and writes corrected results to _sor.rds files in rds_dir.
 #' @export
 
-sor_run <- function(vessel = NULL, cruise = NULL, region = NULL, survey = NULL) {
+sor_run <- function(vessel = NULL, cruise = NULL, region = NULL, survey = NULL, min_pings_for_sor = 50) {
   
     region <- toupper(region)
     stopifnot("run_sor: Region must be 'EBS', 'NBS', 'GOA', or 'AI' " = region %in% c("EBS", "NBS", "GOA", "AI"))  
@@ -38,7 +39,7 @@ sor_run <- function(vessel = NULL, cruise = NULL, region = NULL, survey = NULL) 
       if(is.null(sel_dat$spread)) {
         message("run_sor: No measurement data in ",  rds_path[ii], " Writing output without correcting pings.")
       } else {
-        if(nrow(sel_dat$spread) < 50) {
+        if(nrow(sel_dat$spread) < min_pings_for_sor) {
           message("run_sor: Skipping SOR on ",  rds_path[ii], ". Less than 50 spread pings.")
         } else {
           message("run_sor: Running SOR on ",  rds_path[ii])

--- a/man/sor_run.Rd
+++ b/man/sor_run.Rd
@@ -4,7 +4,13 @@
 \alias{sor_run}
 \title{Function to run sequential outlier rejection on data}
 \usage{
-sor_run(vessel = NULL, cruise = NULL, region = NULL, survey = NULL)
+sor_run(
+  vessel = NULL,
+  cruise = NULL,
+  region = NULL,
+  survey = NULL,
+  min_pings_for_sor = 50
+)
 }
 \arguments{
 \item{vessel}{vessel ID number as a numeric vector (e.g. 162 for Alaska Knight. Must provide rds_dir or all of region, vessel, cruise, survey.}
@@ -14,6 +20,8 @@ sor_run(vessel = NULL, cruise = NULL, region = NULL, survey = NULL)
 \item{region}{Survey region as a 1L character vector (EBS or NBS). Must provide rds_dir or all of region, vessel, cruise, survey.}
 
 \item{survey}{Survey name prefix to use in filename (e.g. NBS_2022). Must provide rds_dir or all of region, vessel, cruise, survey.}
+
+\item{min_pings_for_sor}{Minimum number of ping required to conduct sequential outlier rejection (default = 50).}
 }
 \value{
 Reads in measurement data from _ping.rds files from rds_dir and writes corrected results to _sor.rds files in rds_dir.


### PR DESCRIPTION
Added `min_pings_for_sor` argument to `sor_run` to allow a user-specified minimum number of pings required to run sequential outlier rejection. Addresses #6.